### PR TITLE
Add new order SQL queries

### DIFF
--- a/dist/model/product.js
+++ b/dist/model/product.js
@@ -143,16 +143,18 @@ const add_order_item = db.prepare(/* sql */ `
     INSERT INTO order_items (order_id, product_id, quantity) VALUES (?, ?, ?)
     RETURNING order_id, product_id, quantity
 `);
-const get_product_from_order = db.prepare(/* sql */ `
-   SELECT p.product_name, oi.quantity, oi.price
-   FROM products p
-   LEFT JOIN order_items oi ON oi.product_id = p.product_id
-   WHERE p.product_id = ?
+const select_product_from_order = db.prepare(/* sql */ `
+   SELECT product_name, price
+   FROM products
+   WHERE product_id = ?
 `);
 function addNewOrder({ user_id, products }) {
     const orderId = add_new_order.get(user_id);
     const orders = products.map((product) => {
-        return add_order_item.get(orderId.order_id, product.product_id, product.quantity);
+        let order = add_order_item.get(orderId.order_id, product.product_id, product.quantity);
+        const product_info = select_product_from_order.get(product.product_id);
+        order = Object.assign(Object.assign({}, order), product_info);
+        return order;
     });
     console.log(JSON.stringify(orders));
     return `Order #${orderId.order_id} successfully submitted.`;

--- a/dist/model/product.js
+++ b/dist/model/product.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getProductBySearchTerm = exports.getProductByName = exports.getProductByID = exports.listProductsAll = void 0;
+exports.addNewOrder = exports.getProductBySearchTerm = exports.getProductByName = exports.getProductByID = exports.listProductsAll = void 0;
 //import { db } from 'database/db.sqlite';
 const Database = require('better-sqlite3');
 const db = new Database('database/db.sqlite');
@@ -135,3 +135,43 @@ you can seach by any word in
 -category
 */
 // console.log(getProductBySearchTerm('The'));
+const add_new_order = db.prepare(/* sql */ `
+    INSERT INTO orders (user_id) VALUES (?)
+    RETURNING order_id
+`);
+const add_order_item = db.prepare(/* sql */ `
+    INSERT INTO order_items (order_id, product_id, quantity) VALUES (?, ?, ?)
+    RETURNING order_id, product_id, quantity
+`);
+const get_product_from_order = db.prepare(/* sql */ `
+   SELECT p.product_name, oi.quantity, oi.price
+   FROM products p
+   LEFT JOIN order_items oi ON oi.product_id = p.product_id
+   WHERE p.product_id = ?
+`);
+function addNewOrder({ user_id, products }) {
+    const orderId = add_new_order.get(user_id);
+    const orders = products.map((product) => {
+        return add_order_item.get(orderId.order_id, product.product_id, product.quantity);
+    });
+    console.log(JSON.stringify(orders));
+    return `Order #${orderId.order_id} successfully submitted.`;
+}
+exports.addNewOrder = addNewOrder;
+// Test object to check the addNewOrder function works
+// This mimics what will be passed from the frontend - the user_id and array of products ordered
+// which will contain a product_id and quantity
+const newOrder = {
+    user_id: 1,
+    products: [
+        {
+            product_id: 1,
+            quantity: 1,
+        },
+        {
+            product_id: 2,
+            quantity: 1,
+        },
+    ],
+};
+console.log(addNewOrder(newOrder));

--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -6,9 +6,16 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = __importDefault(require("express"));
 const dotenv_1 = __importDefault(require("dotenv"));
 const productRouter_1 = __importDefault(require("./routes/productRouter"));
+const CORS = require('cors');
 dotenv_1.default.config();
 const app = (0, express_1.default)();
 const port = process.env.PORT || 3000;
+var corsOptions = {
+    origin: ['http://localhost:5173', /^localhost:'/],
+    optionsSuccessStatus: 200,
+    // origin:true -> if you want to allow requests from all origins
+};
+app.use(CORS(corsOptions));
 app.listen(port, () => {
     console.log(`[server]: Server is running at http://localhost:${port}`);
 });

--- a/model/product.ts
+++ b/model/product.ts
@@ -207,23 +207,26 @@ const add_order_item = db.prepare(/* sql */ `
     RETURNING order_id, product_id, quantity
 `);
 
-const get_product_from_order = db.prepare(/* sql */ `
-   SELECT p.product_name, oi.quantity, oi.price
-   FROM products p
-   LEFT JOIN order_items oi ON oi.product_id = p.product_id
-   WHERE p.product_id = ?
+const select_product_from_order = db.prepare(/* sql */ `
+   SELECT product_name, price
+   FROM products
+   WHERE product_id = ?
 `);
 
 export function addNewOrder({ user_id, products }: Order) {
     const orderId: OrderId = add_new_order.get(user_id);
     const orders: Order[] = products.map((product) => {
-        return add_order_item.get(
+        let order = add_order_item.get(
             orderId.order_id,
             product.product_id,
             product.quantity
         );
-    });
 
+        const product_info = select_product_from_order.get(product.product_id);
+
+        order = { ...order, ...product_info };
+        return order;
+    });
     console.log(JSON.stringify(orders));
     return `Order #${orderId.order_id} successfully submitted.`;
 }


### PR DESCRIPTION
Closes #44 

I've added three SQLite queries to `product.ts`, which will be used in the `addNewOrder` function.

- Whenever someone successfully checks out, a new order will be added to the `orders` table, generating an `order_id`.
- Then an object with each individual `order_item` will be returned so it can be displayed on the frontend.
- I combined the order_item with product_info fetched using `product_id`, so the orders array will contain the following keys: order_id, product_id, quantity, product_name, price.

I've kept my test object in the code so you can run `npm run dev` and verify. You should get a result that looks something like the below in your terminal (with different order ids):

```bash
[{"order_id":46,"product_id":1,"quantity":1,"product_name":"The Great Gatsby","price":1099},{"order_id":46,"product_id":2,"quantity":1,"product_name":"To Kill a Mockingbird","price":1299}]
Order #46 successfully submitted.
```

And if you check the order_items and orders tables, you'll see these have been successfully added. (You will need to refresh to see them appear.)