### PR TITLE
potential fix for authentication problems on deployed version

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -76,7 +76,7 @@ export async function login(req: Request, res: Response) {
                         httpOnly: true,
                     });
                 }
-                res.status(200).json({ response: 'Logged in!' });
+                return res.status(200).json({ response: 'Logged in!' });
             });
     } catch (error) {
         res.status(400).json({ error: error });
@@ -104,7 +104,7 @@ export async function signup(req: Request, res: Response) {
                     maxAge: 5 * 60 * 1000,
                     sameSite: 'lax',
                 });
-                res.status(200).json({ response: 'Cookie Created!' });
+                return res.status(200).json({ response: 'Cookie Created!' });
             });
         } catch (error) {
             res.status(400).send(error);
@@ -149,7 +149,7 @@ export function session(req: Request, res: Response) {
         if (sid) {
             const data = getSession(sid);
             const userID = data['user_id'];
-            res.status(200).json({ user_id: userID });
+            return res.status(200).json({ user_id: userID });
         } else throw new Error('No cookie!');
     } catch (error) {
         res.status(400).json({ error: error });


### PR DESCRIPTION
I added return statements to see if it fixes problems with cookies on the deployed version. ChatGPT said to do it, login and sign up still work on my local